### PR TITLE
New Page with Check Boxes and Radio Buttons in All States

### DIFF
--- a/package/yast2-widget-demo.spec
+++ b/package/yast2-widget-demo.spec
@@ -26,7 +26,6 @@ Source0:        %{name}-%{version}.tar.bz2
 Requires:       yast2
 Requires:       yast2-ruby-bindings
 
-BuildRequires:  update-desktop-files
 BuildRequires:  yast2-ruby-bindings
 BuildRequires:  yast2-devtools
 BuildRequires:  yast2
@@ -53,8 +52,8 @@ rake test:unit
 
 
 %install
-%yast_install
-# %suse_update_desktop_file org.opensuse.yast.WidgetDemo
+# No .desktop file here, so we can't use %yast_install
+rake install DESTDIR="%{buildroot}"
 
 
 %files

--- a/package/yast2-widget-demo.spec
+++ b/package/yast2-widget-demo.spec
@@ -60,6 +60,7 @@ rake install DESTDIR="%{buildroot}"
 %defattr(-,root,root)
 %{yast_clientdir}
 %{yast_libdir}
+%{yast_docdir}
 %license COPYING
 
 

--- a/src/lib/widget_demo/dialog.rb
+++ b/src/lib/widget_demo/dialog.rb
@@ -23,6 +23,7 @@ require "widget_demo/pages/selection_widgets"
 require "widget_demo/pages/tables"
 require "widget_demo/pages/item_selector"
 require "widget_demo/pages/simple_widgets"
+require "widget_demo/pages/check_boxes"
 
 Yast.import "UI"
 Yast.import "Wizard"
@@ -73,6 +74,7 @@ module Yast
         nav.add_page(Pages::Tables.new)
         nav.add_page(Pages::ItemSelector.new)
         nav.add_page(Pages::SimpleWidgets.new)
+        nav.add_page(Pages::CheckBoxes.new)
         set_wizard_steps
         show_current_page
 
@@ -130,10 +132,6 @@ module Yast
         delete_wizard_steps
         add_wizard_step_heading("Widget Demo")
         nav.pages.each { |page| add_wizard_step(page.name, page.id) }
-        # FIXME: TO DO
-        ### add_wizard_step_heading("Package Management")
-        ### add_wifzard_step("PatternSelector", "pattern-sel")
-        ### add_wizard_step("PackageSelector", "pkg-sel")
       end
 
       def delete_wizard_steps

--- a/src/lib/widget_demo/pages/check_boxes.rb
+++ b/src/lib/widget_demo/pages/check_boxes.rb
@@ -1,0 +1,120 @@
+#  Copyright (c) 2021 SUSE LLC.
+#  All Rights Reserved.
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of version 2 or 3 of the GNU General
+#  Public License as published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, contact SUSE LLC.
+#
+#  To contact SUSE about this file by physical or electronic mail,
+#  you may find current contact information at www.suse.com
+
+require "yast"
+require "widget_demo/pages/base"
+
+Yast.import "UI"
+
+module Yast
+  module WidgetDemo
+    module Pages
+      # Page with check boxes and radio buttons
+      class CheckBoxes < Base
+        def name
+          "Check Boxes"
+        end
+
+        # The content of this wizard page.
+        # Make sure this still fits into an NCurses 80x24 screen!
+        def content
+          HVSquash(
+            HBox(
+              HWeight(3, Top(check_boxes)),
+              HWeight(2, HStretch()),
+              HWeight(3, Top(radio_boxes))
+            )
+          )
+        end
+
+        def widgets_created
+          # Set some of the check boxes to tri-state ("don't care")
+          UI.ChangeWidget(Id(:cb3), :Value, nil)
+          UI.ChangeWidget(Id(:cb6), :Value, nil)
+        end
+
+        private
+
+        def check_boxes
+          Frame(
+            "Frame",
+            MarginBox(
+              1, 0.2,
+              VBox(
+                Left(CheckBox(Id(:cb1), "Checkbox 1", false)),
+                Left(CheckBox(Id(:cb2), "Checkbox 2", true)),
+                Left(CheckBox(Id(:cb3), "Checkbox 3", false)),
+                VSpacing(1),
+                Left(CheckBox(Id(:cb4), Opt(:disabled), "Checkbox 4", true)),
+                Left(CheckBox(Id(:cb5), Opt(:disabled), "Checkbox 5", false)),
+                Left(CheckBox(Id(:cb6), Opt(:disabled), "Checkbox 6", false)),
+                VStretch()
+              )
+            )
+          )
+        end
+
+        def radio_boxes
+          VBox(
+            radio_box("RadioButton &0"),
+            VSpacing(2),
+            radio_box("RadioButton &3", Opt(:disabled))
+          )
+        end
+
+        # Return a widget term for a radio box
+        #
+        # @param label [String] label pattern for the radio buttons
+        # @param opt [<Yast::Term>] widget options term for each radio button
+        #
+        # @return [<Yast::Term>] widget term
+        #
+        def radio_box(label, opt = nil)
+          Frame(
+            "Frame",
+            MarginBox(
+              1, 0.2,
+              RadioButtonGroup(
+                VBox(
+                  Left(radio_button(opt, label.next!.dup)),
+                  Left(radio_button(opt, label.next!.dup, true)),
+                  Left(radio_button(opt, label.next!.dup))
+                )
+              )
+            )
+          )
+        end
+
+        # Return a term for a RadioButton with or without widget options
+        # @param opt [<Yast::Term>, nil] widget options term
+        # @param label [String] widget label for the radio button
+        # @param checked [Boolean] radio button checked or unchecked?
+        #
+        # @return [<Yast::Term>] widget term
+        #
+        def radio_button(opt, label, checked = false)
+          if opt.nil?
+            RadioButton(label, checked)
+          else
+            RadioButton(opt, label, checked)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/pages_smoke_test.rb
+++ b/test/pages_smoke_test.rb
@@ -24,6 +24,7 @@ require "widget_demo/pages/selection_widgets"
 require "widget_demo/pages/tables"
 require "widget_demo/pages/item_selector"
 require "widget_demo/pages/simple_widgets"
+require "widget_demo/pages/check_boxes"
 
 describe Yast::WidgetDemo::Pages do
 
@@ -60,6 +61,10 @@ describe Yast::WidgetDemo::Pages do
   end
 
   describe Yast::WidgetDemo::Pages::SimpleWidgets do
+    include_examples "page smoke test"
+  end
+
+  describe Yast::WidgetDemo::Pages::CheckBoxes do
     include_examples "page smoke test"
   end
 end


### PR DESCRIPTION
## Description

Follow-up on PR #1 : Added a page with check boxes and radio buttons in all states.

- Check boxes:
  - checked
  - not checked
  - tri-state (don't care)

- Radio buttons:
  - selected
  - not selected
  
  Notice there is no tri-state for radio buttons; that wouldn't make any sense. That would be one more radio button in the radio box.

- All in enabled or disabled state

## Screenshots

![widget-demo-tw-06](https://user-images.githubusercontent.com/11538225/119801916-66b3ab00-bede-11eb-9acd-280682044a9c.png)

![widget-demo-sle15sp3-06](https://user-images.githubusercontent.com/11538225/119801955-6d422280-bede-11eb-9dc2-ceea7d44af23.png)

![widget-demo-ncurses-06](https://user-images.githubusercontent.com/11538225/119801973-703d1300-bede-11eb-9542-03f243d34bd1.png)


## Version Bump?

No. It's still part of the last one, and we haven't created the package yet in OBS anyway.