### PR TITLE
Allow running the widget demo in a Docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Rubocop
       run: rake check:rubocop
 
+    - name: Shellcheck
+      run: shellcheck docker/run.sh
+
   Package:
     runs-on: ubuntu-latest
     container: registry.opensuse.org/yast/head/containers/yast-ruby:latest

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ products.
 2. Press the `Expert Console` button
 3. In the displayed terminal run the `widget_demo` command to start the application
 
+## Running in a Docker Container
+
+You can run the widget demo also in a Docker container, see more details in
+[docker/README.md](docker/README.md).
 
 ## Permissions
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+
+# the default YaST image to use
+ARG image=registry.opensuse.org/yast/head/containers/yast-ruby:latest
+
+FROM ${image}
+
+ENTRYPOINT [ "rake", "run[widget_demo]" ]
+
+# install X11
+RUN zypper --non-interactive install --no-recommends \
+  -t pattern x11
+
+# install the YaST graphical frontend + theme (with font dependencies, etc...)
+RUN zypper --non-interactive install --no-recommends \
+  libyui-qt \
+  yast2-theme

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,9 @@
+## Docker Container
+
+You can run the widget demo also in a Docker container.
+
+Running an X application inside a Docker container is not trivial,
+use the `run.sh` script to build the Docker image and start the container.
+
+When you do not need the Docker image anymore run the `docker rmi widget-demo`
+command to delete the image and free quite some space.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+# to use the 15.3 based image run:
+#
+#   ./run.sh registry.opensuse.org/yast/head/containers_15.3/yast-ruby:latest
+#
+
+# allow customizing the base Docker image
+IMAGE=${1:-registry.opensuse.org/yast/head/containers/yast-ruby:latest}
+
+# build the docker image first (it reuses the built image in the next run)
+docker build --build-arg image="$IMAGE" -t widget-demo .
+
+# get the absolute path to the top source directory,
+# docker does not allow using relative paths for volumes
+topdir="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
+
+# start the container with extra "-e" and "-v" options to allow accessing
+# the local X server from inside the Docker container
+docker run -it -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:ro --net=host \
+    -v "$HOME/.Xauthority:/root/.Xauthority:ro" -v "$topdir:/usr/src/app:ro" \
+    --rm widget-demo


### PR DESCRIPTION
- Added a helper script and Docker image definition to easily run the widget demo in graphics mode (Qt UI) in a Docker container
- That makes running the demo deadly simple
- It also allows trying the widget demo in another Linux distributions easily